### PR TITLE
fix: Module not found: Can't resolve 'queuebase/api' 

### DIFF
--- a/packages/queuebase/package.json
+++ b/packages/queuebase/package.json
@@ -86,7 +86,10 @@
 		"dist/lib",
 		"dist/next",
 		"dist/server",
-		"dist/client"
+		"dist/client",
+		"dist/api",
+		"dist/logger",
+		"dist/constants"
 	],
 	"publishConfig": {
     "access": "public"


### PR DESCRIPTION
Issue that it sovle: #3

This pull request includes changes to the `packages/queuebase/package.json` file. Basically, during the build, not all necessary folders were added to the "dist" folder, resulting in a lack of modules in production

Changes to package distribution:

* [`packages/queuebase/package.json`](diffhunk://#diff-8b77eebd80430e807b5449fa9bb02ecc3423566c7d78548006489b238d662aa1L89-R92): Added `dist/api`, `dist/logger`, and `dist/constants` directories to the `files` array to ensure they are included in the package distribution. 